### PR TITLE
Fix auth token reuse after logout/login

### DIFF
--- a/src/app/core/auth/Auth.intercerptor.ts
+++ b/src/app/core/auth/Auth.intercerptor.ts
@@ -12,34 +12,28 @@ export class AuthInterceptor implements HttpInterceptor {
     constructor(private authService: AuthService) { }
 
     intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-        const isPublicRoute = req.url.includes('/auth/');
+        const isAuthRoute = req.url.includes('/auth/');
+        const accessToken = this.authService.getAccessToken();
 
-        if (this.authService.hasValidToken() && !isPublicRoute) {
-            req = this.addTokenToRequest(req, this.authService.getAccessToken()!);
+        if (accessToken && !isAuthRoute) {
+            req = this.addTokenToRequest(req, accessToken);
         }
 
-        if (this.authService.hasValidToken()) {
-            req = this.addTokenToRequest(req, this.authService.getAccessToken()!);
-        }
         return next.handle(req).pipe(
             catchError((error: HttpErrorResponse) => {
-
-                if (error.status === 401 && !this.isRefreshing) {
-                    return this.handle401Error(req, next);
+                if (error.status !== 401 || isAuthRoute) {
+                    return throwError(() => error);
                 }
 
-                if (error.status === 401 && this.isRefreshing) {
+                if (this.isRefreshing) {
                     return this.refreshTokenSubject.pipe(
                         filter((token) => token !== null),
                         take(1),
-                        switchMap((token) => {
-                            req = this.addTokenToRequest(req, token!);
-                            return next.handle(req);
-                        })
+                        switchMap((token) => next.handle(this.addTokenToRequest(req, token!)))
                     );
                 }
 
-                return throwError(() => error);
+                return this.handle401Error(req, next);
             })
         );
     }
@@ -57,12 +51,11 @@ export class AuthInterceptor implements HttpInterceptor {
                 this.isRefreshing = false;
                 this.refreshTokenSubject.next(response.accessToken);
 
-                request = this.addTokenToRequest(request, response.accessToken);
-                return next.handle(request);
+                return next.handle(this.addTokenToRequest(request, response.accessToken));
             }),
             catchError((error) => {
                 this.isRefreshing = false;
-                this.authService.logout;
+                this.authService.logout();
                 return throwError(() => error);
             })
         )

--- a/src/app/core/auth/Auth.service.ts
+++ b/src/app/core/auth/Auth.service.ts
@@ -23,6 +23,7 @@ export class AuthService {
 
     public login(email: string, password: string): Observable<AuthResponse> {
         const request: LoginRequest = { email, password };
+        this.clearTokens();
 
         return this.http.post<AuthResponse>(`${this.apiUrl}/auth/login`, request)
             .pipe(
@@ -39,6 +40,7 @@ export class AuthService {
 
     public register(email: string, username: string, password: string): Observable<AuthResponse> {
         const request: RegisterRequest = { email, password, username };
+        this.clearTokens();
 
         return this.http.post<AuthResponse>(`${this.apiUrl}/auth/register`, request).pipe(
             tap((response) => {
@@ -53,8 +55,7 @@ export class AuthService {
     }
 
     public logout(): void {
-        localStorage.removeItem("accessToken");
-        localStorage.removeItem("refreshToken");
+        this.clearTokens();
         this.isAuthenticatedSubject.next(false);
         this.currentUserSubject.next(null);
     }
@@ -103,6 +104,14 @@ export class AuthService {
     private saveTokens(accessToken: string, refreshToken: string): void {
         localStorage.setItem("accessToken", accessToken);
         localStorage.setItem("refreshToken", refreshToken);
+    }
+
+    /**
+     * Remove os tokens salvos antes de iniciar uma nova sessão.
+     */
+    private clearTokens(): void {
+        localStorage.removeItem("accessToken");
+        localStorage.removeItem("refreshToken");
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Prevent stale `Authorization` headers from being sent to auth endpoints so a new login doesn't reuse an old access token. 
- Ensure refresh failure actually logs the user out and that new sessions start with a clean token state. 

### Description
- Updated `src/app/core/auth/Auth.intercerptor.ts` to avoid attaching the access token to `/auth/*` requests and to read the token once per intercepted request. 
- Adjusted 401 handling so auth routes are not candidates for refresh and waiting requests use the new token when available. 
- Call `this.authService.logout()` on refresh failure to ensure proper cleanup instead of only referencing the method. 
- Added `clearTokens()` to `src/app/core/auth/Auth.service.ts` and call it before `login` and `register`, and from `logout`, to remove any saved tokens before starting a new session. 

### Testing
- Ran `npm run build` (which runs `ng build`) and the build completed successfully. 
- Build output contained an existing dashboard CSS budget warning but no build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a090d7568588322bd05d8597c71b3d8)